### PR TITLE
Fix AMD-APP-SDK broken link

### DIFF
--- a/docs/guides/mining/XMR-Stak-Linux-Guide.md
+++ b/docs/guides/mining/XMR-Stak-Linux-Guide.md
@@ -14,7 +14,7 @@ If no binaries are available, or you prefer to compile, follow these instruction
 
         * Install drivers for your card
 
-        * download the latest APP SDK from [here](https://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/). It should have the name `AMD-APP-SDKInstaller-v(version number)-GA-linux64.tar.bz2`
+        * download the latest APP SDK from [here](http://debian.nullivex.com/amd/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2). It should have the name `AMD-APP-SDKInstaller-v(version number)-GA-linux64.tar.bz2`
 
             * Extract it
 


### PR DESCRIPTION
The official support for AMD APP SDK has been removed. Please refer this thread for more details https://community.amd.com/thread/228059